### PR TITLE
bug(background-logo): fixed the z-index of the background logo

### DIFF
--- a/src/stylesheets/results-style.css
+++ b/src/stylesheets/results-style.css
@@ -31,6 +31,7 @@ body {
     /* REMOVE THIS LATER */
     margin-bottom: 50px;
     margin-top: 150px;
+    z-index: 1;
 }
 
 .results {
@@ -39,6 +40,7 @@ body {
     background-color: #272727;
     border-radius: 20px;
     margin-bottom: 15px;
+    z-index: 1;
 }
 
 .results-list{

--- a/src/stylesheets/style.css
+++ b/src/stylesheets/style.css
@@ -51,7 +51,7 @@
     height: 832px;
     top: 51px;
     left: 650px;
-    display: none;
+    z-index: 0;
   }
   
   /* blur fade on top */


### PR DESCRIPTION

## Changes
Fixed the issue with the logo background affecting scrolling.
Adjusted the z-index of the .logo-background to ensure it no longer overlaps with the results container.

## Purpose
The background logo was interfering with the scrolling functionality of the results list. This change ensures that the logo does not overlap the main content, allowing users to interact with the results properly.

## Approach
The problem was addressed by adjusting the z-index of the .logo-background element. I set a lower z-index for the logo background and a higher one for the results container to ensure proper layering.

Closes #56 