### PR TITLE
fix: fixed bug that appeared when interns go removed too quickly

### DIFF
--- a/results.js
+++ b/results.js
@@ -312,7 +312,7 @@ document.addEventListener("DOMContentLoaded", () => {
         if (unpaired_intern_info !== undefined)
             {
                 let intern1 = added_intern;
-                let intern2 = remove_unpaired_intern(unpaired_intern_info[1]);
+                let intern2 = remove_unpaired_intern(unpairedInterns,unpaired_intern_info[1]);
                 if(intern2 === undefined)
                     {
                         unpairedInterns.push(intern1);


### PR DESCRIPTION

## Changes
_List Changes Introduced by this PR_
1. Added Missing parameter to function, fixing the resulting bug

## Purpose
When removing interns to quickly the intern_array was not defined due to it being missing
## Approach
it addresses the required references
## Pre-Testing TODOs
- None

## Testing Steps
By doing the same thing that caused the bug until the final output was resolved.
## Learning



Closes #72 
